### PR TITLE
replace deprecated `brew cask` command

### DIFF
--- a/brew-cask-replacer.rb
+++ b/brew-cask-replacer.rb
@@ -26,5 +26,5 @@ Dir.glob('/Applications/*.app').each do |path|
     puts "ERROR: Could not move #{path} to Trash"
     next
   end
-  puts `brew cask install #{token} --appdir=/Applications`
+  puts `brew install --cask #{token} --appdir=/Applications`
 end


### PR DESCRIPTION
`brew cask` is deprecated, using `brew --cask` instead
https://github.com/Homebrew/brew/pull/8899