### PR TITLE
use $HOMEBREW_CASK_OPTS during cask install

### DIFF
--- a/brew-cask-replacer.rb
+++ b/brew-cask-replacer.rb
@@ -26,5 +26,5 @@ Dir.glob('/Applications/*.app').each do |path|
     puts "ERROR: Could not move #{path} to Trash"
     next
   end
-  puts `brew cask install #{token} --appdir=/Applications`
+  puts `brew cask install #{token} $(echo $HOMEBREW_CASK_OPTS)`
 end


### PR DESCRIPTION
Since `--appdir=/Applications` is the default install location (see: https://docs.brew.sh/Manpage#global-cask-options for more defaults), switching the cask install command to use $HOMEBREW_CASK_OPTS so it installs with any existing user defaults